### PR TITLE
Add Auferet (memory-first AI game master)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ ai_skills_library/skills/
 | Folder | Original Repository | Focus Area |
 |---|---|---|
 | `agentscope-skills` | [modelscope/agentscope](https://github.com/modelscope/agentscope) | Multi-agent framework skills |
+[Auferet](https://auferet.com) - AI game master with persistent memory for your characters and uploaded lore; solo or multiplayer, with 5e and Pathfinder 2e modes.
 | `alirezarezvani-skills` | Community contribution | Persian-language AI skills |
 | `anthropics-skills` | [anthropics/anthropic-cookbook](https://github.com/anthropics/anthropic-cookbook) | Official Anthropic prompt recipes |
 | `apify-skills` | [apify/actors-mcp-server](https://github.com/apify/actors-mcp-server) | Web scraping and automation |

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ ai_skills_library/skills/
 | Folder | Original Repository | Focus Area |
 |---|---|---|
 | `agentscope-skills` | [modelscope/agentscope](https://github.com/modelscope/agentscope) | Multi-agent framework skills |
-[Auferet](https://auferet.com) - AI game master with persistent memory for your characters and uploaded lore; solo or multiplayer, with 5e and Pathfinder 2e modes.
+| [Auferet](https://auferet.com) | AI game master that remembers your world: persistent memory for characters, places, and lore you upload; solo or multiplayer, 5e & Pathfinder 2e | — |
 | `alirezarezvani-skills` | Community contribution | Persian-language AI skills |
 | `anthropics-skills` | [anthropics/anthropic-cookbook](https://github.com/anthropics/anthropic-cookbook) | Official Anthropic prompt recipes |
 | `apify-skills` | [apify/actors-mcp-server](https://github.com/apify/actors-mcp-server) | Web scraping and automation |


### PR DESCRIPTION
Adds Auferet, an AI game master for solo and multiplayer roleplaying games. It keeps your characters, world, and events in persistent memory and reads lore you upload, so the story stays consistent across long campaigns. Runs 5e and Pathfinder 2e, plays in the browser and on Android, free to start.

Website: https://auferet.com
